### PR TITLE
Improve Accordion Example

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ function App() {
             </Link>
             <span>
               Panels scroll into view if not fully visible when toggled.
-              Using <pre>useImperativeMethods</pre>, <pre>useRef</pre>.
+              Using <pre>useEffect</pre>, <pre>useRef</pre>.
             </span>
           </div>
           <div className="item">

--- a/src/components/accordion/Accordion.js
+++ b/src/components/accordion/Accordion.js
@@ -1,54 +1,37 @@
-import React, { useRef, createRef, forwardRef, useImperativeMethods, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 
-function useAccordion(panelsCount) {
+function useAccordion() {
   const [currentIndex, setCurrentIndex] = useState();
-  const [refs, setRefs] = useState();
-
-  // This part is smelly
-  // https://github.com/facebook/react/issues/14072
-  // TODO rewrite
-  useEffect(() => {
-    let refs = {};
-    for (let i = 0; i <= panelsCount; i++) {
-      refs[i] = createRef();
-    }
-    setRefs(refs);
-  }, []); // run once
-
-  useEffect(() => {
-    // Scroll current accordion panel into view
-    if (currentIndex !== undefined) {
-      refs[currentIndex].current.scrollIntoView();
-    }
-  }, [currentIndex]); // Run every time current index changes
 
   function setCurrent(newIndex) {
     setCurrentIndex(currentIndex === newIndex ? undefined : newIndex);
   }
 
-  return [currentIndex, setCurrent, refs];
+  return [currentIndex, setCurrent];
 }
 
 // We don't want to re-render this component every time it receives new props
 // We also pass second parameter to this function where we implement our own comparison
 const AccordionPanel = React.memo(
-  forwardRef((props, ref) => {
+  props => {
+    console.log(props.label + " rendered");
     const containerRef = useRef();
 
-    useImperativeMethods(ref, () => ({
-      scrollIntoView: () => {
+    useEffect(() => {
+      if (props.isOpen) {
+        console.log(`scroll ${props.label} into view`);
         scrollIntoView(containerRef.current, { block: 'nearest', scrollMode: 'if-needed' });
       }
-    }));
+    });
 
-    return <div onClick={props.onClick} ref={containerRef}>
-      <div className="accordion-label">{props.label}</div>
-      {props.isOpen &&
-      <div>{props.content}</div>}
-    </div>;
-  }),
-  // practically shouldComponentUpdate, but reversed
+    return (
+      <div onClick={props.onClick} ref={containerRef}>
+        <div className="accordion-label">{props.label}</div>
+        {props.isOpen && <div>{props.content}</div>}
+      </div>
+    );
+  }, // practically shouldComponentUpdate, but reversed
   (prevProps, nextProps) => prevProps.isOpen === nextProps.isOpen
 );
 

--- a/src/components/accordion/index.js
+++ b/src/components/accordion/index.js
@@ -6,12 +6,11 @@ import FoobarIpsum from "foobar-ipsum";
 function AccordionScreen() {
   const panels = [...Array(100).keys()].map(e => `Panel number ${e}`);
 
-  const [currentIndex, setCurrent, refs] = useAccordion(panels.length);
+  const [currentIndex, setCurrent] = useAccordion();
 
   return <Accordion>
     {panels.map((panel, index) => (
       <AccordionPanel
-        ref={refs && refs[index]}
         key={index}
         label={panel}
         content={generateRandomText()}


### PR DESCRIPTION
Don't use an array of refs for the accordion, instead handle scroll into view directly in the panel.